### PR TITLE
[Timeseries]  TS-29-Add-TSKey-majorkey-snapshots

### DIFF
--- a/timeseries-streaming/timeseries-java-applications/TimeSeriesPipeline/src/main/java/com/google/dataflow/sample/timeseriesflow/io/tfexample/TSAccumIterableToTFExample.java
+++ b/timeseries-streaming/timeseries-java-applications/TimeSeriesPipeline/src/main/java/com/google/dataflow/sample/timeseriesflow/io/tfexample/TSAccumIterableToTFExample.java
@@ -41,11 +41,17 @@ public class TSAccumIterableToTFExample
 
   String fileBase;
   Boolean enableMetadataOutput = false;
+  boolean useMajorKeyInFeature = true;
 
   public TSAccumIterableToTFExample() {}
 
   public TSAccumIterableToTFExample(String fileBase) {
     this.fileBase = fileBase;
+  }
+
+  public TSAccumIterableToTFExample(String fileBase, boolean useMajorKeyInFeature) {
+    this.fileBase = fileBase;
+    this.useMajorKeyInFeature = useMajorKeyInFeature;
   }
 
   public TSAccumIterableToTFExample(@Nullable String name, String fileBase) {
@@ -74,7 +80,7 @@ public class TSAccumIterableToTFExample
             input.getPipeline().getOptions().as(TFXOptions.class));
 
     PCollectionTuple exampleAndMetadata =
-        input.apply(new FeaturesFromIterableAccumSequence(timesteps));
+        input.apply(new FeaturesFromIterableAccumSequence(timesteps, useMajorKeyInFeature));
 
     // Send Metadata file to output location
     if (enableMetadataOutput) {

--- a/timeseries-streaming/timeseries-java-applications/TimeSeriesPipeline/src/main/java/com/google/dataflow/sample/timeseriesflow/transforms/MinorKeyWindowSnapshot.java
+++ b/timeseries-streaming/timeseries-java-applications/TimeSeriesPipeline/src/main/java/com/google/dataflow/sample/timeseriesflow/transforms/MinorKeyWindowSnapshot.java
@@ -102,7 +102,7 @@ public class MinorKeyWindowSnapshot {
                       String.join(
                           "-",
                           input.getValue().getWindow().toString(),
-                          input.getKey().getMinorKeyString()))
+                          input.getKey().getMajorKey()))
                   .build(),
               input.getValue().getValue()));
     }

--- a/timeseries-streaming/timeseries-java-applications/TimeSeriesPipeline/src/test/java/com/google/dataflow/sample/timeseriesflow/test/GenerateTFExampleFromTSSequenceTest.java
+++ b/timeseries-streaming/timeseries-java-applications/TimeSeriesPipeline/src/test/java/com/google/dataflow/sample/timeseriesflow/test/GenerateTFExampleFromTSSequenceTest.java
@@ -99,7 +99,7 @@ public class GenerateTFExampleFromTSSequenceTest {
                             .build())))
             .apply(GroupByKey.create())
             .apply(Values.create())
-            .apply(new FeaturesFromIterableAccumSequence(3));
+            .apply(new FeaturesFromIterableAccumSequence(3, true));
 
     PAssert.that(examples.get(FeaturesFromIterableAccumSequence.TIME_SERIES_EXAMPLES))
         .containsInAnyOrder(

--- a/timeseries-streaming/timeseries-java-applications/TimeSeriesPipeline/src/test/java/com/google/dataflow/sample/timeseriesflow/test/SnapShotScalability_1D_100M_100K_1FW_60SW_withTFExampleSerlization.java
+++ b/timeseries-streaming/timeseries-java-applications/TimeSeriesPipeline/src/test/java/com/google/dataflow/sample/timeseriesflow/test/SnapShotScalability_1D_100M_100K_1FW_60SW_withTFExampleSerlization.java
@@ -47,7 +47,7 @@ public class SnapShotScalability_1D_100M_100K_1FW_60SW_withTFExampleSerlization 
 
     Integer timesteps = CommonUtils.getNumOfSequenceTimesteps(p.getOptions().as(TFXOptions.class));
 
-    examples.apply(new FeaturesFromIterableAccumSequence(timesteps));
+    examples.apply(new FeaturesFromIterableAccumSequence(timesteps, true));
 
     p.run();
   }

--- a/timeseries-streaming/timeseries-java-applications/TimeSeriesPipeline/src/test/java/com/google/dataflow/sample/timeseriesflow/test/SnapShotScalability_1D_100M_1K_1FW_60SW_withTFExampleSerlization.java
+++ b/timeseries-streaming/timeseries-java-applications/TimeSeriesPipeline/src/test/java/com/google/dataflow/sample/timeseriesflow/test/SnapShotScalability_1D_100M_1K_1FW_60SW_withTFExampleSerlization.java
@@ -47,7 +47,7 @@ public class SnapShotScalability_1D_100M_1K_1FW_60SW_withTFExampleSerlization {
 
     Integer timesteps = CommonUtils.getNumOfSequenceTimesteps(p.getOptions().as(TFXOptions.class));
 
-    examples.apply(new FeaturesFromIterableAccumSequence(timesteps));
+    examples.apply(new FeaturesFromIterableAccumSequence(timesteps, true));
 
     p.run();
   }

--- a/timeseries-streaming/timeseries-java-applications/TimeSeriesPipeline/src/test/java/com/google/dataflow/sample/timeseriesflow/test/SnapshotTests.java
+++ b/timeseries-streaming/timeseries-java-applications/TimeSeriesPipeline/src/test/java/com/google/dataflow/sample/timeseriesflow/test/SnapshotTests.java
@@ -335,11 +335,11 @@ public class SnapshotTests {
         .inWindow(
             new IntervalWindow(
                 Instant.ofEpochMilli(TSDataTestUtils.START), Duration.standardSeconds(5)))
-        .containsInAnyOrder(2L, 1L)
+        .containsInAnyOrder(3L)
         .inWindow(
             new IntervalWindow(
                 Instant.ofEpochMilli(TSDataTestUtils.PLUS_FIVE_SECS), Duration.standardSeconds(5)))
-        .containsInAnyOrder(1L, 1L, 2L);
+        .containsInAnyOrder(2L, 2L);
 
     p.run();
   }
@@ -347,8 +347,6 @@ public class SnapshotTests {
   public static class ExtractSequenceCountPerMajorKey extends DoFn<Iterable<TSAccum>, Long> {
     @ProcessElement
     public void process(@Element Iterable<TSAccum> accums, OutputReceiver<Long> o) {
-      System.out.println("Yippee");
-      accums.forEach(x -> System.out.println(x.getKey().getMinorKeyString()));
       o.output(StreamSupport.stream(accums.spliterator(), true).count());
     }
   }


### PR DESCRIPTION
Fix bug with wrong value used for GBK.
Add TFExample output without major key as part of feature name.