### PR TITLE
Add terraform scripts for pubsub and enable related APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,9 @@ sdks/python/postcommit_requirements.txt
 
 .pytest_cache
 .pytest_cache/**/*
+
+# Terraform intermediate artifacts
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*

--- a/retail/retail-java-applications/README.MD
+++ b/retail/retail-java-applications/README.MD
@@ -201,3 +201,5 @@ VALUES
 * Create a BigTable instance within your project
 #### Create a table
 * Create the "PageView5MinAggregates" table with Column family "pageViewAgg"
+# Deploy Using Terraform
+Please refer to [this document](terraform/README.MD) to deploy resources using terraform

--- a/retail/retail-java-applications/terraform/README.MD
+++ b/retail/retail-java-applications/terraform/README.MD
@@ -1,0 +1,124 @@
+# Deploy using Terraform
+
+Use Terraform to deploy the folllowing services defined in the `main.tf` file
+
+- Pub/Sub
+
+## Install Terraform
+
+If you are using the [Google Cloud Shell](https://cloud.google.com/shell/docs/how-cloud-shell-works), Terraform is already installed.
+
+Follow the instructions to [install the Terraform cli](https://learn.hashicorp.com/tutorials/terraform/install-cli?in=terraform/gcp-get-started).
+
+This repo has been tested on Terraform version `0.14.5` and the Google provider version `3.48.0`
+
+## Edit Values of Variables If Desired
+The values of variables can be found in terraform.tfvars as shown below. 
+
+```
+region                     = "us-central1"
+topic_clickstream_inbound  = "Clickstream-inbound"
+topic_transactions_inbound = "Transactions-inbound"
+topic_inventory_inbound    = "Inventory-inbound"
+topic_inventory_outbound   = "Inventory-outbound"
+clickstream_inbound_sub    = "Clickstream-inbound-sub"
+transactions_inbound_sub   = "Transactions-inbound-sub"
+inventory_inbound_sub      = "Inventory-inbound-sub"
+```
+
+You can change these resources' names if there is a need to do so.
+
+For example, if you want to change the topic name of clickstream inbound to "Clickstream-topic", just edit the name accordingly as shown below and save it.
+
+```
+topic_clickstream_inbound  = "Clickstream-topic"
+```
+
+However, the value "us-central1" must be a [valid region](https://cloud.google.com/compute/docs/regions-zones/viewing-regions-zones) in order to proceed.
+
+Terraform will pick up these values during execution as described in the later section.
+
+## Initialize Terraform
+
+```
+terraform init
+```
+
+You should see the following output
+
+```
+Initializing the backend...
+
+Initializing provider plugins...
+- Reusing previous version of hashicorp/google from the dependency lock file
+- Installing hashicorp/google v3.48.0...
+- Installed hashicorp/google v3.48.0 (signed by HashiCorp)
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your working directory. If you forget, other
+commands will detect it and remind you to do so if necessary.
+```
+
+## Create resources in Google Cloud
+
+Run the plan command to see what resources will be created in your project. Please enter your project ID when prompted.
+```
+terraform plan
+```
+When prompted, please enter your project ID.
+
+```
+var.project_id
+  Project ID in GCP
+
+  Enter a value:
+```
+A list of resources planning to be created will be shown.
+
+Run the apply command and point to your `.tfvars` file to deploy all the resources in your project.
+
+```
+terraform apply -var-file terraform.tfvars
+```
+
+In addition to what the plan command does, the apply command asks you to confirm your deployment action by entering `yes` to proceed:
+
+```
+Plan: 8 to add, 0 to change, 0 to destroy.
+
+Do you want to perform these actions?
+  Terraform will perform the actions described above.
+  Only 'yes' will be accepted to approve.
+
+  Enter a value:
+```
+If you are confident about the changes, you can add an additional flag "-auto-approve" to the apply command. This allows the apply command to proceed without typing `yes`.
+
+```
+terraform apply -auto-approve -var-file terraform.tfvars
+```
+
+## Terraform output
+
+Once everything has successfully run you should see the following output:
+
+```
+google_project_service.pubsub: Creating...
+.
+.
+.
+google_pubsub_subscription.transactions_inbound_sub: Creation complete after 12s [id=projects/[your project ID]/subscriptions/Transactions-inbound-sub]
+Apply complete! Resources: 8 added, 0 changed, 0 destroyed.
+```
+## Terraform Destroy
+
+Use Terraform to destroy all resources
+```
+terraform destroy
+```

--- a/retail/retail-java-applications/terraform/main.tf
+++ b/retail/retail-java-applications/terraform/main.tf
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.48.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+//enable pubsub API
+resource "google_project_service" "pubsub" {
+  service = "pubsub.googleapis.com"
+  disable_on_destroy = false
+}
+
+//create pubsub resources
+resource "google_pubsub_topic" "topic_clickstream_inbound" {
+  name = var.topic_clickstream_inbound
+  labels = {
+    created = "terraform"
+  }
+
+  depends_on = [google_project_service.pubsub]
+}
+
+resource "google_pubsub_topic" "topic_transactions_inbound" {
+  name = var.topic_transactions_inbound
+
+  labels = {
+    created = "terraform"
+  }
+
+  depends_on = [google_project_service.pubsub]
+}
+
+resource "google_pubsub_topic" "topic_inventory_inbound" {
+  name = var.topic_inventory_inbound
+
+  labels = {
+    created = "terraform"
+  }
+
+  depends_on = [google_project_service.pubsub]
+}
+
+resource "google_pubsub_topic" "topic_inventory_outbound" {
+  name = var.topic_inventory_outbound
+
+  labels = {
+    created = "terraform"
+  }
+
+  depends_on = [google_project_service.pubsub]
+}
+
+resource "google_pubsub_subscription" "clickstream_inbound_sub" {
+  name  = var.clickstream_inbound_sub
+  topic = google_pubsub_topic.topic_clickstream_inbound.name
+
+  labels = {
+    created = "terraform"
+  }
+  
+  retain_acked_messages      = false
+
+  ack_deadline_seconds       = 20
+
+  enable_message_ordering    = false
+}
+
+resource "google_pubsub_subscription" "transactions_inbound_sub" {
+  name  = var.transactions_inbound_sub
+  topic = google_pubsub_topic.topic_transactions_inbound.name
+
+  labels = {
+    created = "terraform"
+  }
+  
+  retain_acked_messages      = false
+
+  ack_deadline_seconds       = 20
+
+  enable_message_ordering    = false
+}
+
+resource "google_pubsub_subscription" "inventory_inbound_sub" {
+  name  = var.inventory_inbound_sub
+  topic = google_pubsub_topic.topic_inventory_inbound.name
+
+  labels = {
+    created = "terraform"
+  }
+  
+  retain_acked_messages      = false
+
+  ack_deadline_seconds       = 20
+
+  enable_message_ordering    = false
+}

--- a/retail/retail-java-applications/terraform/terraform.tfvars
+++ b/retail/retail-java-applications/terraform/terraform.tfvars
@@ -1,0 +1,25 @@
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+# project_id = "xl-project-302106"
+region                     = "us-central1"
+topic_clickstream_inbound  = "Clickstream-inbound"
+topic_transactions_inbound = "Transactions-inbound"
+topic_inventory_inbound    = "Inventory-inbound"
+topic_inventory_outbound   = "Inventory-outbound"
+clickstream_inbound_sub    = "Clickstream-inbound-sub"
+transactions_inbound_sub   = "Transactions-inbound-sub"
+inventory_inbound_sub      = "Inventory-inbound-sub"

--- a/retail/retail-java-applications/terraform/variables.tf
+++ b/retail/retail-java-applications/terraform/variables.tf
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type        = string
+  description = "Project ID in GCP"
+}
+
+variable "region" {
+  type    = string
+}
+
+variable "topic_clickstream_inbound" {
+  type    = string
+}
+
+variable "topic_transactions_inbound" {
+  type    = string
+}
+
+variable "topic_inventory_inbound" {
+  type    = string
+}
+
+variable "topic_inventory_outbound" {
+  type    = string
+}
+
+variable "clickstream_inbound_sub" {
+  type    = string
+}
+
+variable "transactions_inbound_sub" {
+  type    = string
+}
+
+variable "inventory_inbound_sub" {
+  type    = string
+}
+


### PR DESCRIPTION
**Purpose:** automate deployment of pubsub components and organise terraform scripts in a separate folder
**Related files:**
- retail/retail-java-applications/terraform/main.tf
- retail/retail-java-applications/terraform/variables.tf
- retail/retail-java-applications/terraform/terraform.tfvars

**Purpose:** document usage of terraform scripts and organise terraform scripts in a separate folder
**Related files:**
- retail/retail-java-applications/terraform/README.MD
- retail/retail-java-applications/README.MD

**Purpose:** ignore intermediate terraform artifacts
**Related files:**
- .gitignore

First round reviewed by @tzehon.