### PR TITLE
Fix typo in transforms labels

### DIFF
--- a/retail/retail-java-applications/data-engineering-dept/business-logic/src/main/java/com/google/dataflow/sample/retail/businesslogic/core/utils/JSONUtils.java
+++ b/retail/retail-java-applications/data-engineering-dept/business-logic/src/main/java/com/google/dataflow/sample/retail/businesslogic/core/utils/JSONUtils.java
@@ -104,7 +104,7 @@ public class JSONUtils {
       PCollection<ErrorMsg> errorMsgs =
           result
               .getFailedToParseLines()
-              .apply("CreateRows", ParDo.of(new CreateErrorEvents(errMessageSchema)))
+              .apply("CreateErrorRows", ParDo.of(new CreateErrorEvents(errMessageSchema)))
               .setRowSchema(errMessageSchema)
               .apply("ConvertRowsToErrMsg", Convert.fromRows(ErrorMsg.class));
 

--- a/retail/retail-java-applications/data-engineering-dept/business-logic/src/main/java/com/google/dataflow/sample/retail/businesslogic/core/utils/JSONUtils.java
+++ b/retail/retail-java-applications/data-engineering-dept/business-logic/src/main/java/com/google/dataflow/sample/retail/businesslogic/core/utils/JSONUtils.java
@@ -104,9 +104,9 @@ public class JSONUtils {
       PCollection<ErrorMsg> errorMsgs =
           result
               .getFailedToParseLines()
-              .apply("CreateErrorMessages", ParDo.of(new CreateErrorEvents(errMessageSchema)))
+              .apply("CreateRows", ParDo.of(new CreateErrorEvents(errMessageSchema)))
               .setRowSchema(errMessageSchema)
-              .apply("ConvertErrMsgToRows", Convert.fromRows(ErrorMsg.class));
+              .apply("ConvertRowsToErrMsg", Convert.fromRows(ErrorMsg.class));
 
       if (sinkType != null) {
         errorMsgs.apply(DeadLetterSink.createSink(sinkType));


### PR DESCRIPTION
A very minor PR (only changes in label strings). 

I think the first step transforms from `Row` to `Row` (with a simplified schema?), and the second step converts from `Row` to `ErrorMsg`.